### PR TITLE
Patches to compile on FreeBSD

### DIFF
--- a/HxCFloppyEmulator_cmdline/build/Makefile
+++ b/HxCFloppyEmulator_cmdline/build/Makefile
@@ -34,6 +34,11 @@ LIBHXCFE= libhxcfe.dylib
 LIBUSBHXCFE= libusbhxcfe.dylib
 endif
 
+ifeq ($(TARGET), FreeBSD)
+CC=cc
+LDFLAGS += -lc -lm -ldl -lpthread -Wl,-rpath=. -Wl,-Map,foo.map
+endif
+
 ifeq ($(TARGET), Linux)
 LDFLAGS += -lc -lm -ldl -lpthread -Wl,-rpath=. -Wl,-Map,foo.map
 endif

--- a/HxCFloppyEmulator_software/build/Makefile
+++ b/HxCFloppyEmulator_software/build/Makefile
@@ -36,6 +36,14 @@ endif
 LIBHXCFE = libhxcfe.so
 LIBUSBHXCFE = libusbhxcfe.so
 
+ifeq ($(TARGET), FreeBSD)
+CC=cc
+CPP=c++
+BUILD_CC=cc
+CFLAGS += -I/usr/local/include
+LDFLAGS += -lc -lm -ldl -lpthread -Wl,-rpath=.  -Wl,-Map,foo.map
+endif
+
 ifeq ($(TARGET), Linux)
 LDFLAGS += -lc -lm -ldl -lpthread -Wl,-rpath=.  -Wl,-Map,foo.map
 endif
@@ -89,8 +97,7 @@ all:
 	$(MAKE) $(EXEC)
 
 fltk:
-	chmod +x ../sources/thirdpartylibs/fltk/prepare_fltk.sh
-	cd ../sources/thirdpartylibs/fltk/ && ./prepare_fltk.sh
+	cd ../sources/thirdpartylibs/fltk/ && bash ./prepare_fltk.sh
 ifeq ($(TARGET), mingw32)
 		cd ../sources/thirdpartylibs/fltk/fltk-1.x.x/ && export LDFLAGS='-static-libstdc++ -static-libgcc' && ./configure --host=i686-w64-mingw32 --prefix=/usr/share/mingw-w64
 		$(MAKE) -C ../sources/thirdpartylibs/fltk/fltk-1.x.x/ DIRS=src CC=i686-w64-mingw32-gcc CPP=i686-w64-mingw32-g++

--- a/libhxcadaptor/build/Makefile
+++ b/libhxcadaptor/build/Makefile
@@ -23,6 +23,12 @@ ifeq ($(DEBUG_ASAN), 1)
 	LDFLAGS += -static-libasan -fsanitize=address
 endif
 
+ifeq ($(TARGET), FreeBSD)
+CFLAGS += -fPIC -Wl,-Map,foo.map
+LDFLAGS += -lc -lm -ldl
+CC=cc
+endif
+
 ifeq ($(TARGET), Linux)
 CFLAGS += -fPIC -Wl,-Map,foo.map
 LDFLAGS += -lc -lm -ldl

--- a/libhxcadaptor/sources/libhxcadaptor.c
+++ b/libhxcadaptor/sources/libhxcadaptor.c
@@ -220,10 +220,10 @@ void* hxc_createcriticalsection(HXCFE* floppycontext,unsigned char id)
 
 	pthread_mutexattr_init(&mAttr);
 
-#if defined(__APPLE__)
+#if defined(PTHREAD_MUTEX_RECURSIVE)
 	// setup recursive mutex for mutex attribute
 	pthread_mutexattr_settype(&mAttr, PTHREAD_MUTEX_RECURSIVE);
-#else
+#elif defined (PTHREAD_MUTEX_RECURSIVE_NP)
 	pthread_mutexattr_settype(&mAttr, PTHREAD_MUTEX_RECURSIVE_NP);
 #endif
 	// Use the mutex attribute to create the mutex

--- a/libhxcfe/build/Makefile
+++ b/libhxcfe/build/Makefile
@@ -26,6 +26,13 @@ endif
 
 EXEC=libhxcfe.so
 
+ifeq ($(TARGET), FreeBSD)
+CC=cc
+BUILD_CC=cc
+CFLAGS += -fPIC -Wl,-Map,foo.map
+LDFLAGS += -lc -lm  -ldl
+endif
+
 ifeq ($(TARGET), Linux)
 CFLAGS += -fPIC -Wl,-Map,foo.map
 LDFLAGS += -lc -lm  -ldl

--- a/libusbhxcfe/build/Makefile
+++ b/libusbhxcfe/build/Makefile
@@ -1,5 +1,5 @@
 #CC=i386-pc-linux-gcc
-#CC=gcc
+CC=gcc
 AR=ar
 
 TARGET := $(shell uname)

--- a/libusbhxcfe/build/Makefile
+++ b/libusbhxcfe/build/Makefile
@@ -1,5 +1,5 @@
 #CC=i386-pc-linux-gcc
-CC=gcc
+#CC=gcc
 AR=ar
 
 TARGET := $(shell uname)
@@ -24,6 +24,12 @@ ifeq ($(DEBUG_ASAN), 1)
 endif
 
 EXEC=libusbhxcfe.so
+
+ifeq ($(TARGET), FreeBSD)
+CC=cc
+CFLAGS += -fPIC -Wl,-Map,foo.map
+LDFLAGS += -lc -lm  -ldl
+endif
 
 ifeq ($(TARGET), Linux)
 CFLAGS += -fPIC -Wl,-Map,foo.map


### PR DESCRIPTION
These changes enables me to compile HxC's software on FreeBSD.
 
1. Clone the "ifeq ($(TARGET), Linux)" to ...FreeBSD and set CC/CPP appropriately
2. Explicitly run prepare_fltk.sh with bash, this avoids a chmod in the source tree and works on FreeBSD where bash lives in /usr/local/bin
3. Select PTHREAD_MUTEX_RECURSIVE(_NP) depending on what is defined, rather than the OS.
