### PR TITLE
Add support for Centurion sector format

### DIFF
--- a/HxCFloppyEmulator_software/sources/gui/cb_floppy_infos_window.cxx
+++ b/HxCFloppyEmulator_software/sources/gui/cb_floppy_infos_window.cxx
@@ -420,6 +420,7 @@ int InfosThreadProc(void* floppycontext,void* context)
 			hxcfe_td_activate_analyzer(td,C64_GCR_ENCODING,w->c64_bt->value());
 			hxcfe_td_activate_analyzer(td,VICTOR9K_GCR_ENCODING,w->victor9k_bt->value());
 			hxcfe_td_activate_analyzer(td,MICRALN_HS_FM_ENCODING,w->heathkit_bt->value());
+			hxcfe_td_activate_analyzer(td,CENTURION_MFM_ENCODING,w->centurion_bt->value());
 
 			hxcfe_td_setparams(td,(int)(adjust_timescale(w->x_time->value())),(int)w->y_time->value(),(int)(w->x_offset->value()*1000),0);
 

--- a/HxCFloppyEmulator_software/sources/gui/floppy_infos_window.cxx
+++ b/HxCFloppyEmulator_software/sources/gui/floppy_infos_window.cxx
@@ -39,7 +39,7 @@ floppy_infos_window::floppy_infos_window() {
       } // Fl_Choice* view_mode
       o->end();
     } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(1000, 2, 275, 284, getString(STR_FLOPPYVIEWERWINDOW_0005));
+    { Fl_Group* o = new Fl_Group(1000, 2, 275, 269, getString(STR_FLOPPYVIEWERWINDOW_0005));
       o->box(FL_ENGRAVED_FRAME);
       o->labeltype(FL_ENGRAVED_LABEL);
       o->labelsize(12);
@@ -102,71 +102,75 @@ floppy_infos_window::floppy_infos_window() {
       } // Fl_Button* o
       o->end();
     } // Fl_Group* o
-    { Fl_Group* o = new Fl_Group(1000, 287, 275, 101, getString(STR_FLOPPYVIEWERWINDOW_0014));
+    { Fl_Group* o = new Fl_Group(1000, 272, 275, 117, getString(STR_FLOPPYVIEWERWINDOW_0014));
       o->box(FL_ENGRAVED_FRAME);
       o->labeltype(FL_EMBOSSED_LABEL);
       o->labelsize(10);
       o->align(Fl_Align(FL_ALIGN_TOP_LEFT|FL_ALIGN_INSIDE));
-      { iso_mfm_bt = new Fl_Light_Button(1015, 305, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0015));
+      { iso_mfm_bt = new Fl_Light_Button(1015, 290, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0015));
         iso_mfm_bt->labelsize(10);
         iso_mfm_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* iso_mfm_bt
-      { iso_fm_bt = new Fl_Light_Button(1015, 320, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0016));
+      { iso_fm_bt = new Fl_Light_Button(1015, 305, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0016));
         iso_fm_bt->labelsize(10);
         iso_fm_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* iso_fm_bt
-      { amiga_mfm_bt = new Fl_Light_Button(1015, 335, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0017));
+      { amiga_mfm_bt = new Fl_Light_Button(1015, 320, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0017));
         amiga_mfm_bt->labelsize(10);
         amiga_mfm_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* amiga_mfm_bt
-      { membrain_bt = new Fl_Light_Button(1099, 335, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0018));
+      { membrain_bt = new Fl_Light_Button(1099, 320, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0018));
         membrain_bt->labelsize(10);
         membrain_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* membrain_bt
-      { tycom_bt = new Fl_Light_Button(1099, 320, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0019));
+      { tycom_bt = new Fl_Light_Button(1099, 305, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0019));
         tycom_bt->labelsize(10);
         tycom_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* tycom_bt
-      { eemu_bt = new Fl_Light_Button(1099, 305, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0020));
+      { eemu_bt = new Fl_Light_Button(1099, 290, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0020));
         eemu_bt->labelsize(10);
         eemu_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* eemu_bt
-      { apple2_bt = new Fl_Light_Button(1015, 350, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0021));
+      { apple2_bt = new Fl_Light_Button(1015, 335, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0021));
         apple2_bt->labelsize(10);
         apple2_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* apple2_bt
-      { arburg_bt = new Fl_Light_Button(1099, 350, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0022));
+      { arburg_bt = new Fl_Light_Button(1099, 335, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0022));
         arburg_bt->labelsize(10);
         arburg_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* arburg_bt
-      { aed6200p_bt = new Fl_Light_Button(1183, 305, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0023));
+      { aed6200p_bt = new Fl_Light_Button(1183, 290, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0023));
         aed6200p_bt->labelsize(10);
         aed6200p_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* aed6200p_bt
-      { northstar_bt = new Fl_Light_Button(1183, 320, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0024));
+      { northstar_bt = new Fl_Light_Button(1183, 305, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0024));
         northstar_bt->labelsize(10);
         northstar_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* northstar_bt
-      { heathkit_bt = new Fl_Light_Button(1183, 335, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0025));
+      { heathkit_bt = new Fl_Light_Button(1183, 320, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0025));
         heathkit_bt->labelsize(10);
         heathkit_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* heathkit_bt
-      { decrx02_bt = new Fl_Light_Button(1183, 350, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0026));
+      { decrx02_bt = new Fl_Light_Button(1183, 335, 76, 15, getString(STR_FLOPPYVIEWERWINDOW_0026));
         decrx02_bt->labelsize(10);
         decrx02_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* decrx02_bt
-      { c64_bt = new Fl_Light_Button(1015, 365, 76, 15, "C64");
+      { c64_bt = new Fl_Light_Button(1015, 350, 76, 15, "C64");
         c64_bt->labelsize(10);
         c64_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* c64_bt
-      { qd_mo5_bt = new Fl_Light_Button(1183, 365, 76, 15, "QD MO5");
+      { qd_mo5_bt = new Fl_Light_Button(1183, 350, 76, 15, "QD MO5");
         qd_mo5_bt->labelsize(10);
         qd_mo5_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* qd_mo5_bt
-      { victor9k_bt = new Fl_Light_Button(1099, 365, 76, 15, "Victor 9K");
+      { victor9k_bt = new Fl_Light_Button(1099, 350, 76, 15, "Victor 9K");
         victor9k_bt->labelsize(10);
         victor9k_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
       } // Fl_Light_Button* victor9k_bt
+      { centurion_bt = new Fl_Light_Button(1015, 365, 76, 15, "Centurion");
+        centurion_bt->labelsize(10);
+        centurion_bt->callback((Fl_Callback*)disk_infos_window_callback, (void*)(this));
+      } // Fl_Light_Button* centurion_bt
       o->end();
     } // Fl_Group* o
 

--- a/HxCFloppyEmulator_software/sources/gui/floppy_infos_window.h
+++ b/HxCFloppyEmulator_software/sources/gui/floppy_infos_window.h
@@ -50,6 +50,7 @@ public:
   Fl_Light_Button *c64_bt;
   Fl_Light_Button *qd_mo5_bt;
   Fl_Light_Button *victor9k_bt;
+  Fl_Light_Button *centurion_bt;
   Fl_Text_Buffer* buf;
   Fl_Text_Display * txt_displ;
 };

--- a/HxCFloppyEmulator_software/sources/gui/fluid/floppy_infos_window.fl
+++ b/HxCFloppyEmulator_software/sources/gui/fluid/floppy_infos_window.fl
@@ -35,7 +35,7 @@ class floppy_infos_window {open
       }
       Fl_Group {} {
         label Status open
-        xywh {1000 2 275 284} box ENGRAVED_FRAME labeltype ENGRAVED_LABEL labelsize 12 align 21
+        xywh {1000 2 275 269} box ENGRAVED_FRAME labeltype ENGRAVED_LABEL labelsize 12 align 21
       } {
         Fl_Output x_pos {
           xywh {1005 17 265 15} labelsize 10 textsize 10
@@ -48,7 +48,7 @@ class floppy_infos_window {open
         }
         Fl_Text_Display object_txt {
           user_data this
-          xywh {1005 68 265 215} labelsize 10 textsize 10
+          xywh {1005 68 265 200} labelsize 10 textsize 10
         }
       }
       Fl_Group floppy_map_disp {
@@ -92,97 +92,103 @@ class floppy_infos_window {open
       }
       Fl_Group {} {
         label {Track analysis format} open
-        xywh {1000 287 275 102} box ENGRAVED_FRAME labeltype EMBOSSED_LABEL labelsize 10 align 21
+        xywh {1000 272 275 117} box ENGRAVED_FRAME labeltype EMBOSSED_LABEL labelsize 10 align 21
       } {
         Fl_Light_Button iso_mfm_bt {
           label {ISO MFM}
           user_data this
           callback disk_infos_window_callback
-          xywh {1015 305 76 15} labelsize 10
+          xywh {1015 290 76 15} labelsize 10
         }
         Fl_Light_Button iso_fm_bt {
           label {ISO FM}
           user_data this
           callback disk_infos_window_callback
-          xywh {1015 320 76 15} labelsize 10
+          xywh {1015 305 76 15} labelsize 10
         }
         Fl_Light_Button amiga_mfm_bt {
           label {AMIGA MFM}
           user_data this
           callback disk_infos_window_callback
-          xywh {1015 335 76 15} labelsize 10
+          xywh {1015 320 76 15} labelsize 10
         }
         Fl_Light_Button membrain_bt {
           label MEMBRAIN
           user_data this
           callback disk_infos_window_callback
-          xywh {1099 335 76 15} labelsize 10
+          xywh {1099 320 76 15} labelsize 10
         }
         Fl_Light_Button tycom_bt {
           label TYCOM
           user_data this
           callback disk_infos_window_callback
-          xywh {1099 320 76 15} labelsize 10
+          xywh {1099 305 76 15} labelsize 10
         }
         Fl_Light_Button eemu_bt {
           label {E-Emu}
           user_data this
           callback disk_infos_window_callback
-          xywh {1099 305 76 15} labelsize 10
+          xywh {1099 290 76 15} labelsize 10
         }
         Fl_Light_Button apple2_bt {
           label Apple
           user_data this
           callback disk_infos_window_callback
-          xywh {1015 350 76 15} labelsize 10
+          xywh {1015 335 76 15} labelsize 10
         }
         Fl_Light_Button arburg_bt {
           label Arburg
           user_data this
           callback disk_infos_window_callback
-          xywh {1099 350 76 15} labelsize 10
+          xywh {1099 335 76 15} labelsize 10
         }
         Fl_Light_Button aed6200p_bt {
           label {AED 6200P}
           user_data this
           callback disk_infos_window_callback
-          xywh {1183 305 76 15} labelsize 10
+          xywh {1183 290 76 15} labelsize 10
         }
         Fl_Light_Button northstar_bt {
           label NORTHSTAR
           user_data this
           callback disk_infos_window_callback
-          xywh {1183 320 76 15} labelsize 10
+          xywh {1183 305 76 15} labelsize 10
         }
         Fl_Light_Button heathkit_bt {
           label HEATHKIT
           user_data this
           callback disk_infos_window_callback
-          xywh {1183 335 76 15} labelsize 10
+          xywh {1183 320 76 15} labelsize 10
         }
         Fl_Light_Button decrx02_bt {
           label {DEC RX02}
           user_data this
           callback disk_infos_window_callback
-          xywh {1183 350 76 15} labelsize 10
+          xywh {1183 335 76 15} labelsize 10
         }
         Fl_Light_Button c64_bt {
           label C64
           user_data this
           callback disk_infos_window_callback
-          xywh {1015 365 76 15} labelsize 10
+          xywh {1015 350 76 15} labelsize 10
         }
         Fl_Light_Button qd_mo5_bt {
           label {QD MO5}
           user_data this
           callback disk_infos_window_callback
-          xywh {1183 365 76 15} labelsize 10
+          xywh {1183 350 76 15} labelsize 10
         }
         Fl_Light_Button victor9k_bt {
           label {Victor 9K}
           user_data this
           callback disk_infos_window_callback
-          xywh {1099 365 76 15} labelsize 10
+          xywh {1099 350 76 15} labelsize 10
+        }
+        Fl_Light_Button centurion_bt {
+          label Centurion
+          user_data this
+          callback disk_infos_window_callback selected
+          xywh {1015 365 76 15} labelsize 10
         }
       }
     }

--- a/libhxcfe/build/Makefile
+++ b/libhxcfe/build/Makefile
@@ -113,7 +113,7 @@ DISKWRITERPLUGINS = cpcdsk_writer.o mfm_writer.o hfe_writer.o raw_writer.o afi_w
 
 TRACK_FORMATS_SUPPORT = luts.o track_types_defs.o aed6200p_track.o amiga_mfm_track.o apple2_gcr_track.o arburg_track.o emu_emulator_fm_track.o c64_gcr_track.o \
 						heathkit_fm_track.o iso_ibm_fm_track.o iso_ibm_mfm_track.o membrain_mfm_track.o northstar_mfm_track.o tycom_fm_track.o dec_rx02_track.o \
-						apple_mac_gcr_track.o qd_mo5_track.o victor9k_gcr_track.o micraln_fm_track.o
+						apple_mac_gcr_track.o qd_mo5_track.o victor9k_gcr_track.o micraln_fm_track.o centurion_mfm_track.o
 
 ENCODING_SUPPORT = fm_encoding.o mfm_encoding.o dec_m2fm_encoding.o
 
@@ -218,6 +218,9 @@ emu_emulator_fm_track.o : $(BASEDIR)/tracks/track_formats/emu_emulator_fm_track.
 	$(CC) -o $@ -c $< $(CFLAGS)
 
 c64_gcr_track.o : $(BASEDIR)/tracks/track_formats/c64_gcr_track.c $(BASEDIR)/tracks/track_formats/c64_gcr_track.h
+	$(CC) -o $@ -c $< $(CFLAGS)
+
+centurion_mfm_track.o : $(BASEDIR)/tracks/track_formats/centurion_mfm_track.c $(BASEDIR)/tracks/track_formats/centurion_mfm_track.h
 	$(CC) -o $@ -c $< $(CFLAGS)
 
 victor9k_gcr_track.o : $(BASEDIR)/tracks/track_formats/victor9k_gcr_track.c $(BASEDIR)/tracks/track_formats/victor9k_gcr_track.h

--- a/libhxcfe/sources/libhxcfe.h
+++ b/libhxcfe/sources/libhxcfe.h
@@ -243,6 +243,7 @@ int32_t                hxcfe_floppySectorBySectorCopy( HXCFE* floppycontext, HXC
 #define C64_GCR                          0x15
 #define VICTOR9K_GCR                     0x16
 #define MICRALN_HS_SD                    0x17
+#define CENTURION_DD                     0x18
 
 #define DIRECT_ENCODING                  0xFE
 
@@ -441,6 +442,7 @@ int32_t                hxcfe_FDC_SCANSECTOR  ( HXCFE* floppycontext, uint8_t tra
 #define C64_GCR_ENCODING                 0x12
 #define VICTOR9K_GCR_ENCODING            0x13
 #define MICRALN_HS_FM_ENCODING           0x14
+#define CENTURION_MFM_ENCODING           0x15
 #define UNKNOWN_ENCODING                 0xFF
 
 enum {

--- a/libhxcfe/sources/tracks/sector_extractor.c
+++ b/libhxcfe/sources/tracks/sector_extractor.c
@@ -64,6 +64,7 @@
 #include "tracks/track_formats/apple_mac_gcr_track.h"
 #include "tracks/track_formats/arburg_track.h"
 #include "tracks/track_formats/c64_gcr_track.h"
+#include "tracks/track_formats/centurion_mfm_track.h"
 #include "tracks/track_formats/dec_rx02_track.h"
 #include "tracks/track_formats/emu_emulator_fm_track.h"
 #include "tracks/track_formats/heathkit_fm_track.h"
@@ -239,7 +240,9 @@ HXCFE_SECTCFG* hxcfe_getNextSector( HXCFE_SECTORACCESS* ss_ctx, int32_t track, i
 		case MICRALN_HS_FM_ENCODING:
 			bitoffset = get_next_FM_MicralN_sector(ss_ctx->hxcfe,ss_ctx->fp->tracks[track]->sides[side],sc,bitoffset);
 		break;
-
+		case CENTURION_MFM_ENCODING:
+			bitoffset = get_next_Centurion_MFM_sector(ss_ctx->hxcfe,ss_ctx->fp->tracks[track]->sides[side],sc,bitoffset);
+		break;
 		default:
 			bitoffset=-1;
 		break;

--- a/libhxcfe/sources/tracks/track_formats/centurion_mfm_track.c
+++ b/libhxcfe/sources/tracks/track_formats/centurion_mfm_track.c
@@ -1,0 +1,194 @@
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "types.h"
+
+#include "internal_libhxcfe.h"
+#include "tracks/track_generator.h"
+#include "sector_search.h"
+#include "fdc_ctrl.h"
+
+#include "libhxcfe.h"
+
+#include "tracks/sector_extractor.h"
+#include "tracks/crc.h"
+
+#include "tracks/track_formats/centurion_mfm_track.h"
+
+#include "tracks/trackutils.h"
+#include "tracks/encoding/mfm_encoding.h"
+
+#include "tracks/luts.h"
+
+#include "sector_sm.h"
+
+int get_next_Centurion_MFM_sector(HXCFE* floppycontext,HXCFE_SIDE * track,HXCFE_SECTCFG * sector,int track_offset)
+{
+	int bit_offset;
+	int tmp_bit_offset;
+	int sector_extractor_sm;
+	unsigned char mfm_buffer[32];
+	unsigned char tmp_buffer[32];
+	int last_start_offset;
+	unsigned char CRC16_High;
+	unsigned char CRC16_Low;
+	unsigned char crctable[32];
+	int k;
+
+	memset(sector,0,sizeof(HXCFE_SECTCFG));
+
+	bit_offset=track_offset;
+
+	sector_extractor_sm=LOOKFOR_GAP1;
+
+	do
+	{
+		switch(sector_extractor_sm)
+		{
+			case LOOKFOR_GAP1:
+				floppycontext->hxc_printf(MSG_DEBUG, "Looking for Centurion sector mark starting at %d\n", bit_offset);
+
+				mfm_buffer[0] = 0x91;
+				mfm_buffer[1] = 0x22;
+				mfm_buffer[2] = 0x44;
+				mfm_buffer[3] = 0x89;
+
+				bit_offset = searchBitStream(track->databuffer,track->tracklen,-1,mfm_buffer,4*8,bit_offset);
+
+				if(bit_offset!=-1)
+				{
+					last_start_offset = bit_offset;
+					floppycontext->hxc_printf(MSG_DEBUG, "Found Centurion MFM sector mark at offset %d\n", bit_offset);
+					sector_extractor_sm=LOOKFOR_ADDM;
+				}
+				else
+				{
+					sector_extractor_sm=ENDOFTRACK;
+				}
+			break;
+			case LOOKFOR_ADDM:
+				sector->startsectorindex=bit_offset;
+
+				// Skip over sector mark
+				bit_offset = chgbitptr(track->tracklen, bit_offset, 4*8);
+
+				// Read out sector header
+				bit_offset = mfmtobin(track->databuffer,NULL,track->tracklen,tmp_buffer,4,bit_offset,0);
+				sector->cylinder = tmp_buffer[0];
+				sector->sector = tmp_buffer[1];
+				sector->header_crc = (tmp_buffer[2] << 8) | tmp_buffer[3];
+
+				// Assume CRCs are bad initially
+				sector->use_alternate_header_crc = 0xFF;
+				sector->use_alternate_data_crc = 0xFF;
+
+				// Calculate CCITT/XMODEM CRC16 over sector header
+				CRC16_Init(&CRC16_High,&CRC16_Low,(unsigned char*)crctable,0x1021,0x0);
+				for(k=0;k<4;k++)
+				{
+					CRC16_Update(&CRC16_High,&CRC16_Low, tmp_buffer[k],(unsigned char*)crctable );
+				}
+
+				if(!CRC16_High && !CRC16_Low)
+				{ // crc ok !!!
+					floppycontext->hxc_printf(MSG_DEBUG, "Valid Centurion MFM sector header found - Cyl: %d Sect:%d\n", sector->cylinder, sector->sector);
+					sector->use_alternate_header_crc = 0;
+				}
+				else
+				{
+					floppycontext->hxc_printf(MSG_DEBUG, "Bad Centurion MFM sector header found - Cyl: %d, Sect:%d\n", sector->cylinder, sector->sector);
+				}
+
+				if(track->timingbuffer)
+					sector->bitrate = track->timingbuffer[bit_offset/8];
+				else
+					sector->bitrate = track->bitrate;
+
+				// Give some room for a write splice
+				bit_offset = chgbitptr(track->tracklen, bit_offset, 400);
+
+				// Look for end of gap.
+				mfm_buffer[0] = 0xAA;
+				mfm_buffer[1] = 0xAA;
+				mfm_buffer[2] = 0xAA;
+				mfm_buffer[3] = 0xA9;
+
+				tmp_bit_offset = searchBitStream(track->databuffer, track->tracklen, -1, mfm_buffer, 4*8, bit_offset);
+				if(tmp_bit_offset != -1)
+				{
+					// Skip past gap.
+					bit_offset = chgbitptr(track->tracklen, tmp_bit_offset, 4*8);
+
+					// Read out sector key.  This seems to be some sort of
+					// encryption key identifier.  Only zero has been observed
+					// so far which seems to indicate no encryption.
+					bit_offset = mfmtobin(track->databuffer, NULL, track->tracklen, tmp_buffer, 1, bit_offset, 0);
+					int sector_key = tmp_buffer[0];
+
+					if (sector_key == 0) {
+						// Initialize CRC16 that will be computed over data header,
+						// payload, and trailing CRC
+						CRC16_Init(&CRC16_High,&CRC16_Low,(unsigned char*)crctable,0x1021,0x0);
+
+						// Read out data header which is just the sector size
+						bit_offset = mfmtobin(track->databuffer, NULL, track->tracklen, tmp_buffer, 2, bit_offset, 0);
+						sector->sectorsize = (tmp_buffer[0] << 8) | tmp_buffer[1];
+						CRC16_Update(&CRC16_High,&CRC16_Low, tmp_buffer[0],(unsigned char*)crctable );
+						CRC16_Update(&CRC16_High,&CRC16_Low, tmp_buffer[1],(unsigned char*)crctable );
+
+						sector->startdataindex = bit_offset;
+
+						// Read data bytes
+						sector->input_data = (unsigned char*)malloc(sector->sectorsize);
+						memset(sector->input_data, 0, sector->sectorsize);
+
+						sector->input_data_index = (int*)malloc(sector->sectorsize*sizeof(int));
+						memset(sector->input_data_index, 0, sector->sectorsize * sizeof(int));
+
+						bit_offset = mfmtobin(track->databuffer,sector->input_data_index,track->tracklen,sector->input_data,sector->sectorsize,bit_offset,0);
+
+						for(k=0; k < sector->sectorsize; k++)
+						{
+							CRC16_Update(&CRC16_High,&CRC16_Low, sector->input_data[k],(unsigned char*)crctable );
+						}
+
+						// Data CRC is immediately after
+						bit_offset = mfmtobin(track->databuffer, NULL, track->tracklen, tmp_buffer, 2, bit_offset, 0);
+						sector->data_crc = (tmp_buffer[0] << 8) | tmp_buffer[1];
+						CRC16_Update(&CRC16_High,&CRC16_Low, tmp_buffer[0],(unsigned char*)crctable );
+						CRC16_Update(&CRC16_High,&CRC16_Low, tmp_buffer[1],(unsigned char*)crctable );
+
+						if(!CRC16_High && !CRC16_Low)
+						{ // crc ok !!!
+							floppycontext->hxc_printf(MSG_DEBUG, "Valid Centurion MFM data found - Cyl: %d Sect:%d\n", sector->cylinder, sector->sector);
+							sector->use_alternate_data_crc = 0;
+						}
+						else
+						{
+							floppycontext->hxc_printf(MSG_DEBUG, "Bad Centurion MFM data found - Cyl: %d, Sect:%d\n", sector->cylinder, sector->sector);
+						}
+					} else {
+						floppycontext->hxc_printf(MSG_DEBUG, "Don't know how to decode Centurion MFM sector key %d", sector_key);
+					}
+
+					sector->endsectorindex = bit_offset;
+					sector_extractor_sm=ENDOFSECTOR;
+				} else {
+					sector->startdataindex = bit_offset;
+					sector->endsectorindex = bit_offset;
+
+					bit_offset = chgbitptr( track->tracklen, bit_offset, 1 );
+
+					sector_extractor_sm=ENDOFSECTOR;
+				}
+			break;
+			default:
+				sector_extractor_sm=ENDOFTRACK;
+			break;
+
+		}
+	}while(	(sector_extractor_sm!=ENDOFTRACK) && (sector_extractor_sm!=ENDOFSECTOR));
+
+	return bit_offset;
+}

--- a/libhxcfe/sources/tracks/track_formats/centurion_mfm_track.h
+++ b/libhxcfe/sources/tracks/track_formats/centurion_mfm_track.h
@@ -1,0 +1,1 @@
+int get_next_Centurion_MFM_sector(HXCFE* floppycontext,HXCFE_SIDE * track,HXCFE_SECTCFG * sector,int track_offset);


### PR DESCRIPTION
Centurion is a 1980s minicomputer that has been brought back to life by @nakazoto.  As part of a longer term effort to support using a floppy disk emulator with the system, a small group of us reverse engineered Centurion's custom floppy disk sector format (see https://github.com/Nakazoto/CenturionComputer/wiki/Format-on-Disk#format-on-floppy-drive).  I heavily leveraged HxC during that process to visualize the flux data and work out key parts of the sector format.  The result is this set of patches which provide full Centurion sector decoding to the track analyzer.

[CentSSDD.zip](https://github.com/jfdelnero/HxCFloppyEmulator/files/12604756/CentSSDD.zip) contains an HFE disk image created from an 8" SSDD floppy that was freshly formatted by the Centurion operating system.  This can be used to verify that all sectors are being found and both the sector header and data checksums are found to be correct.
