### PR TITLE
Added parameter to adfReleaseDevice declaration

### DIFF
--- a/libhxcfe/sources/thirdpartylibs/adflib/Docs/API.txt
+++ b/libhxcfe/sources/thirdpartylibs/adflib/Docs/API.txt
@@ -209,7 +209,7 @@ The structure 'struct nativeFunctions' must have at least :
   BOOL (*adfNativeReadSector)(struct Device*, long, int, unsigned char*)
   BOOL (*adfNativeWriteSector)(struct Device*, long, int, unsigned char*)
   BOOL (*adfIsDevNative)(char*)
-  void (*adfReleaseDevice)()
+  void (*adfReleaseDevice)(struct Device *)
 
 
 For example, adfMountDev() calls adfInitDevice() this way :

--- a/libhxcfe/sources/thirdpartylibs/adflib/Lib/adf_nativ.h
+++ b/libhxcfe/sources/thirdpartylibs/adflib/Lib/adf_nativ.h
@@ -54,7 +54,7 @@ struct nativeFunctions{
     /* called by adfMount() */
     BOOL (*adfIsDevNative)(char*);
     /* called by adfUnMount() */
-    RETCODE (*adfReleaseDevice)();
+    RETCODE (*adfReleaseDevice)(struct Device *);
 };
 
 void adfInitNativeFct();


### PR DESCRIPTION
Parameter was missing in the function prototype for adfReleaseDevice which was causing build failures (gcc 15.1.1 20250425 , Arch Linux). Confirmed project built and application runs after fix.