### PR TITLE
Fix md5sum locale issue by forcing LC_ALL=C

### DIFF
--- a/HxCFloppyEmulator_software/sources/thirdpartylibs/fltk/prepare_fltk.sh
+++ b/HxCFloppyEmulator_software/sources/thirdpartylibs/fltk/prepare_fltk.sh
@@ -10,6 +10,7 @@ md5_check () {
 			return 1;
 		fi;
 	else
+		export LC_ALL=C
 		export valid_md5=`echo ${DOWNLOADHASH} ${ARCHIVENAMEBASE}.tar.gz | md5sum -c - | grep ": OK" | wc -l`
 
 		if [ "$valid_md5" -ne "1" ]; then


### PR DESCRIPTION
md5sum messages are sometimes localized.
Example, in French, md5sum returns "Réussi" instead of "OK", as expected by the script `prepare_fltk.sh`

This difference leads the script to think there's a problem with the download and rejects the file fltk-1.4.2-source.tar.gz

Adding `LC_ALL=C` before calling md5sum should force md5sum to return non localized message "OK".