### PR TITLE
macOS improvements : fix CAPSImage loading (again), make CLI more portable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.dylib
 *.app
 *.dmg
+dosdiskbrowser
 hxcfe
 bmptoh
 hxcfloppyemulator

--- a/HxCFloppyEmulator_cmdline/build/Makefile
+++ b/HxCFloppyEmulator_cmdline/build/Makefile
@@ -38,8 +38,10 @@ LIBUSBHXCFE = libusbhxcfe.so
 ifeq ($(TARGET), Darwin)
 	MACOSX_ARCH ?= -arch arm64 -arch x86_64
 	MACOSX_MIN_VER ?= 10.9
+	# Allow the CLI to run from the App bundle or from somewhere like /usr/local/bin (with libs in /usr/local/lib)
+	RPATHS = -Wl,-rpath,@executable_path/../Frameworks,-rpath,@executable_path/../lib
 	CFLAGS += ${MACOSX_ARCH} -mmacosx-version-min=${MACOSX_MIN_VER}
-	LDFLAGS += -lc -lm -ldl -lpthread ${MACOSX_ARCH} -mmacosx-version-min=${MACOSX_MIN_VER}
+	LDFLAGS += -lc -lm -ldl -lpthread ${MACOSX_ARCH} -mmacosx-version-min=${MACOSX_MIN_VER} ${RPATHS}
 	LIBHXCFE = libhxcfe.dylib
 	LIBUSBHXCFE = libusbhxcfe.dylib
 endif

--- a/HxCFloppyEmulator_software/build/Makefile
+++ b/HxCFloppyEmulator_software/build/Makefile
@@ -93,8 +93,10 @@ endif
 ifeq ($(TARGET), Darwin)
 	MACOSX_ARCH ?= -arch arm64 -arch x86_64
 	MACOSX_MIN_VER ?= 10.9
+	# For the GUI application, libraries will always be in the Frameworks directory.
+	RPATHS = -Wl,-rpath,@executable_path/../Frameworks
 	CFLAGS += -DOSX ${MACOSX_ARCH} -mmacosx-version-min=${MACOSX_MIN_VER}
-	LDFLAGS += -lc -lm -ldl -lpthread -framework Cocoa -framework AudioToolBox -framework UniformTypeIdentifiers ${MACOSX_ARCH} -mmacosx-version-min=${MACOSX_MIN_VER}
+	LDFLAGS += -lc -lm -ldl -lpthread -framework Cocoa -framework AudioToolBox -framework UniformTypeIdentifiers ${MACOSX_ARCH} -mmacosx-version-min=${MACOSX_MIN_VER} ${RPATHS}
 	LIBHXCFE = libhxcfe.dylib
 	LIBUSBHXCFE = libusbhxcfe.dylib
 else

--- a/build/Makefile
+++ b/build/Makefile
@@ -48,7 +48,7 @@ mrproper:
 	-rm -rf *.dylib
 	-rm -rf *.dmg
 	-rm -rf *.app
-	-rm -rf hxcfe_cmdline
+	-rm -rf dosdiskbrowser
 	-rm -rf hxcfloppyemulator
 	-rm -f  hxcfe
 	-rm -rf Debug_*

--- a/build/maccreatebundle
+++ b/build/maccreatebundle
@@ -1,30 +1,39 @@
 #!/usr/bin/env bash
-export VERSION=`grep "define STR_FILE_VERSION2" version.h | cut -f2 -d\"`
+VERSION=`grep "define STR_FILE_VERSION2" version.h | cut -f2 -d\"`
 
-if [ "$1" = "HXCSOFT" ]; then
-export NAME="HxCFloppyEmulator"
-export DMGNAME="HxCFloppyEmulator"
-
-export CLI_PATH="hxcfe_cmdline"
-export CLI_EXEC="hxcfe"
-
-export GUI_PATH="HxCFloppyEmulator.app"
-export GUI_EXEC="hxcfloppyemulator"
+case "$1" in
+  HXCSOFT)
+	NAME="HxCFloppyEmulator"
+	DMGNAME="HxCFloppyEmulator"
+	INSTALL_PATH="HxCFloppyEmulator.app"
+	LIBS="libhxcfe.dylib libusbhxcfe.dylib"
+	GUI_EXEC="hxcfloppyemulator"
+	CLI_EXEC="hxcfe"
+	;;
+  DOSDISKBROWSER)
+	NAME="DosDiskBrowser"
+	DMGNAME="DosDiskBrowser"
+	INSTALL_PATH="DosDiskBrowser.app"
+	LIBS="libhxcfe.dylib"
+	GUI_EXEC="dosdiskbrowser"
+	CLI_EXEC=""
+	;;
+  *)
+	echo "Usage: $0 {HXCSOFT|DOSDISKBROWSER}"
+	exit 1
+	;;
+esac
 
 echo Creating App bundle : ${NAME}
 
-mkdir -p ${CLI_PATH}/{Frameworks,App}
-install hxcfe ${CLI_PATH}/App/${CLI_EXEC}
-install libhxcfe.dylib libusbhxcfe.dylib ${CLI_PATH}/Frameworks
+mkdir -p ${INSTALL_PATH}/Contents/{Resources,MacOS,Frameworks}
 
-mkdir -p ${GUI_PATH}/Contents/{Resources,MacOS,Frameworks}
+echo APPLnone > ${INSTALL_PATH}/Contents/PkgInfo
+iconutil --convert icns --output ${INSTALL_PATH}/Contents/Resources/icons.icns ../HxCFloppyEmulator_software/sources/mac/icons/hxcfloppyemulator.iconset/
+install ${GUI_EXEC} ${CLI_EXEC} ${INSTALL_PATH}/Contents/MacOS
+install ${LIBS} ${INSTALL_PATH}/Contents/Frameworks
 
-echo APPLnone > ${GUI_PATH}/Contents/PkgInfo
-iconutil --convert icns --output ${GUI_PATH}/Contents/Resources/icons.icns ../HxCFloppyEmulator_software/sources/mac/icons/hxcfloppyemulator.iconset/
-install hxcfloppyemulator ${GUI_PATH}/Contents/MacOS/${GUI_EXEC}
-install libhxcfe.dylib libusbhxcfe.dylib ${GUI_PATH}/Contents/Frameworks
-
-cat << EOF > ${GUI_PATH}/Contents/info.plist
+cat << EOF > ${INSTALL_PATH}/Contents/info.plist
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
 <plist version="0.9">
@@ -47,51 +56,22 @@ cat << EOF > ${GUI_PATH}/Contents/info.plist
 </plist>
 EOF
 
-hdiutil create ${DMGNAME}.dmg -srcfolder ${CLI_PATH} -srcfolder ${GUI_PATH} -ov -volname ${DMGNAME}
+if [ -n "${CLI_EXEC}" ]; then
 
-fi
+cat << EOF > ${INSTALL_PATH}/Contents/MacOS/README
+${CLI_EXEC} is the command line version of ${NAME}.
+It can run from here, or be installed to /usr/local/bin or any other convenient directory \
+in your PATH.
+It will look for its libraries (${LIBS}) in ../lib or ../Frameworks relative to the executable.
 
-if [ "$1" = "DOSDISKBROWSER" ]; then
-
-export NAME="DosDiskBrowser"
-export DMGNAME="DosDiskBrowser"
-
-export GUI_PATH="DosDiskBrowser.app"
-export GUI_EXEC="dosdiskbrowser"
-
-echo Creating App bundle : ${NAME}
-
-mkdir -p ${GUI_PATH}/Contents/{Resources,MacOS,Frameworks}
-
-echo APPLnone > ${GUI_PATH}/Contents/PkgInfo
-iconutil --convert icns --output ${GUI_PATH}/Contents/Resources/icons.icns ../HxCFloppyEmulator_software/sources/mac/icons/hxcfloppyemulator.iconset/
-install dosdiskbrowser ${GUI_PATH}/Contents/MacOS/${GUI_EXEC}
-install libhxcfe.dylib ${GUI_PATH}/Contents/Frameworks
-
-cat << EOF > ${GUI_PATH}/Contents/info.plist
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
-<plist version="0.9">
-<dict>
-		<key>CFBundleIdentifier</key>
-		<string>com.hxc2001.${GUI_EXEC}</string>
-		<key>CFBundleName</key>
-		<string>${NAME}</string>
-		<key>CFBundlePackageType</key>
-		<string>APPL</string>
-		<key>CFBundleVersion</key>
-		<string>1</string>
-		<key>CFBundleShortVersionString</key>
-		<string>${VERSION}</string>
-		<key>CFBundleIconFile</key>
-		<string>icons.icns</string>
-		<key>CFBundleSignature</key>
-		<string>none</string>
-</dict>
-</plist>
+To use SPS CapsLib / CAPSImage for IPF support, install it in one of \
+the following locations :
+- the same directory as libhxcfe.dylib
+- /Library/Frameworks
+- /usr/local/lib
+and make sure the SPSCAPS_LIB_NAME internal parameter is set to the correct name.
 EOF
 
-hdiutil create ${DMGNAME}.dmg -srcfolder ${GUI_PATH} -ov -volname ${DMGNAME}
-
 fi
 
+hdiutil create ${DMGNAME}.dmg -srcfolder ${INSTALL_PATH} -ov -volname ${DMGNAME}

--- a/libhxcfe/build/Makefile
+++ b/libhxcfe/build/Makefile
@@ -73,8 +73,11 @@ endif
 ifeq ($(TARGET), Darwin)
 	MACOSX_ARCH ?= -arch arm64 -arch x86_64
 	MACOSX_MIN_VER ?= 10.9
+	# Search paths for other dylibs (like CAPSImage)
+	# @loader_path = same directory as this lib.
+	RPATHS = -Wl,-rpath,@loader_path,-rpath,/Library/Frameworks,-rpath,/usr/local/lib
 	CFLAGS += ${MACOSX_ARCH} -mmacosx-version-min=${MACOSX_MIN_VER}
-	LDFLAGS += -lc -lm -ldl ${MACOSX_ARCH} -dynamiclib -current_version 2.0 -install_name @executable_path/../Frameworks/libhxcfe.dylib -mmacosx-version-min=${MACOSX_MIN_VER}
+	LDFLAGS += -lc -lm -ldl ${MACOSX_ARCH} -dynamiclib -current_version 2.0 -install_name @rpath/libhxcfe.dylib -mmacosx-version-min=${MACOSX_MIN_VER} ${RPATHS}
 	EXEC = libhxcfe.dylib
 endif
 

--- a/libhxcfe/sources/floppy_loader.c
+++ b/libhxcfe/sources/floppy_loader.c
@@ -134,7 +134,7 @@ HXCFE* hxcfe_init(void)
 #if defined(WIN32)
 		hxcfe_execScriptLine( hxcfe, "set SPSCAPS_LIB_NAME CAPSImg.dll" );
 #elif __APPLE__
-		hxcfe_execScriptLine( hxcfe, "set SPSCAPS_LIB_NAME CAPSImage.framework/CAPSImage,CAPSImg.framework/CAPSImg" );
+		hxcfe_execScriptLine( hxcfe, "set SPSCAPS_LIB_NAME @rpath/CAPSImage.framework/CAPSImage,@rpath/CAPSImg.framework/CAPSImg" );
 #else
 		hxcfe_execScriptLine( hxcfe, "set SPSCAPS_LIB_NAME libcapsimage.so.5,libcapsimage.so.5.1,libcapsimage.so" );
 #endif

--- a/libusbhxcfe/build/Makefile
+++ b/libusbhxcfe/build/Makefile
@@ -66,7 +66,9 @@ ifeq ($(TARGET), Darwin)
 	MACOSX_ARCH ?= -arch arm64 -arch x86_64
 	MACOSX_MIN_VER ?= 10.9
 	CFLAGS += ${MACOSX_ARCH} -mmacosx-version-min=${MACOSX_MIN_VER}
-	LDFLAGS +=  -lc -lm -ldl ${MACOSX_ARCH} -dynamiclib -current_version 2.0 -install_name @executable_path/../Frameworks/libusbhxcfe.dylib -mmacosx-version-min=${MACOSX_MIN_VER}
+	# Load libhxcfe from the same directory as this library.
+	RPATHS = -Wl,-rpath,@loader_path
+	LDFLAGS +=  -lc -lm -ldl ${MACOSX_ARCH} -dynamiclib -current_version 2.0 -install_name @rpath/libusbhxcfe.dylib -mmacosx-version-min=${MACOSX_MIN_VER} ${RPATHS}
 	EXEC = libusbhxcfe.dylib
 endif
 


### PR DESCRIPTION
This is a follow-up to my [previous PR](https://github.com/jfdelnero/HxCFloppyEmulator/pull/12) 2 years ago which fixed CAPSImage loading on macOS.

Unfortunately the dynamic linker in macOS changed its default search behaviour at the end of 2023 and my previous fix was incomplete : CAPSImage was no longer loading for me.

Dynamic lib loading in macOS is more flexible but also much more complex to understand than LD_LIBRARY_PATH in Linux (you have to set the search paths yourself at link time, or later using `install_name_tool`). So I found [a good explanation](https://itwenty.me/posts/01-understanding-rpath/) and I think I finally fixed it :

- libhxcfe will now look for external libraries (i.e. CAPSImage) in the current dir, or `/Library/Frameworks`, or `/usr/local/lib`
- libusbhxcfe will always look for libhxcfe in the same directory
- `hxcfe` CLI now looks for its libraries in `../Frameworks` or `../lib`, so you can install it to `/usr/local/bin` (and the libs to `/usr/local/lib`) for example.
- Simplified `maccreatebundle` for DosDiskBrowser.
- I also removed the separate folder for the CLI in the Mac bundle : now it's just next to the GUI executable (many other macOS apps do this when they have a CLI) and no need for duplicate Frameworks. I added a README to explain that it can be relocated if needed.

One problem I noticed (I think it was already there ?) : `SPSCAPS_LIB_NAME` is set to `@rpath/CAPSImage.framework/CAPSImage,@rpath/CAPSImg.framework/CAPSImg` but in the GUI / Internal Parameters I only see '@rpath/CAPSImage.framework/CAPSImage'. Unfortunately I don't have time to check how the parser works to find the issue.
