### PR TITLE
dependencies for building under Ubuntu

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,8 +67,9 @@ Build folder.
 
 ### Linux target
 
-(Linux build environment)
+(Linux build environment like Ubuntu)
 ```
+sudo apt-get install libxft-dev libfreetype6-dev pkg-config
 cd hxc_floppy_emulator_sources_path/build
 make
 ```


### PR DESCRIPTION
Updated README with additional build instructions under Ubuntu

otherwise you will get the error

```
Package xft was not found in the pkg-config search path.
Perhaps you should add the directory containing `xft.pc'
to the PKG_CONFIG_PATH environment variable
Package 'xft', required by 'virtual:world', not found
Package freetype2 was not found in the pkg-config search path.
Perhaps you should add the directory containing `freetype2.pc'
to the PKG_CONFIG_PATH environment variable
Package 'freetype2', required by 'virtual:world', not found
checking for freetype-config... no
configure: please install pkg-config or use 'configure --disable-xft'.
configure: error: Aborting.
```